### PR TITLE
Fix ApiException not found and Exception thrown when transaction Id not found

### DIFF
--- a/Paystack.php
+++ b/Paystack.php
@@ -656,7 +656,7 @@ class PaystackHttpResponse
         $resp = \json_decode($this->body);
 
         if ($resp === null || !property_exists($resp, 'status') || !$resp->status) {
-            throw new ApiException(
+            throw new PaystackExceptionApiException(
                 "Paystack Request failed with Response: '" .
                 $this->messageFromApiJson($resp)."'",
                 $resp

--- a/Paystack.php
+++ b/Paystack.php
@@ -655,14 +655,6 @@ class PaystackHttpResponse
     {
         $resp = \json_decode($this->body);
 
-        if ($resp === null || !property_exists($resp, 'status') || !$resp->status) {
-            throw new PaystackExceptionApiException(
-                "Paystack Request failed with Response: '" .
-                $this->messageFromApiJson($resp)."'",
-                $resp
-            );
-        }
-
         return $resp;
     }
 
@@ -696,9 +688,6 @@ class PaystackHttpResponse
     {
         if ($this->okay && $this->forApi) {
             return $this->parsePaystackPaystackHttpResponse();
-        }
-        if (!$this->okay && $this->forApi) {
-            throw new \Exception($this->implodedMessages());
         }
         if ($this->okay) {
             return $this->body;


### PR DESCRIPTION
ApiException not found fix by removing the code block for the unknown exception while returning the actual status of the request when there is error connecting to Paystack.

The Exception thrown when Transaction Id is not found is removed for the request to return proper response indicating the status of the transaction id provided.
